### PR TITLE
[FEAT] 씨앗 응원 기능을 위한 바텀 시트 구현

### DIFF
--- a/src/components/feature/detail/comment/CheerUpBottomSheet.tsx
+++ b/src/components/feature/detail/comment/CheerUpBottomSheet.tsx
@@ -1,0 +1,22 @@
+import { BottomSheet } from '@/components/common/bottomSheet';
+import { Typography } from '@/components/common/typography/Typography';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const CheerUpBottomSheet = ({ isOpen, onClose: closeSheetHandler }: Props) => {
+  return (
+    <BottomSheet open={isOpen} onDismiss={closeSheetHandler}>
+      <div className="flex flex-col gap-2 px-4 py-4">
+        <Typography type="heading1">응원해준 친구 목록</Typography>
+        <Typography type="heading3" className="text-primary-300">
+          기능 준비중
+        </Typography>
+      </div>
+    </BottomSheet>
+  );
+};
+
+export default CheerUpBottomSheet;

--- a/src/components/feature/detail/comment/CheerUpButton.tsx
+++ b/src/components/feature/detail/comment/CheerUpButton.tsx
@@ -1,0 +1,25 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+import SunIcon from '@/assets/icon/SunIcon';
+import Button from '@/components/common/button/Button';
+import { Typography } from '@/components/common/typography/Typography';
+
+interface CheerUpButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  onOpen: VoidFunction;
+}
+
+export const CheerUpButton = ({ onOpen, ...props }: CheerUpButtonProps) => {
+  const handleOpenComments = () => {
+    // open(({ isOpen, close }) => <CommentsBottomSheet open={isOpen} onClose={close} goalId={targetGoalId} />);
+    onOpen();
+  };
+
+  return (
+    <Button className="items-center bg-gray-10" onClick={handleOpenComments} {...props}>
+      <SunIcon width={30} height={30} />
+      <Typography type="section1" className="text-gray-40">
+        {/* {numberOfComments > 0 ? `${numberOfComments}개의 댓글` : '댓글 작성하기'} */}
+      </Typography>
+    </Button>
+  );
+};

--- a/src/components/feature/seed/seedDetail/CommonSeedDetailBody.tsx
+++ b/src/components/feature/seed/seedDetail/CommonSeedDetailBody.tsx
@@ -1,15 +1,16 @@
-import SunIcon from '@/assets/icon/SunIcon';
-import Button from '@/components/common/button/Button';
 import { Tag } from '@/components/common/tag';
 import { ToolTip } from '@/components/common/toolTip';
 import { Typography } from '@/components/common/typography/Typography';
-import useToast from '@/hooks/useToast';
+import useBottomSheetState from '@/hooks/useBottomSheetState';
 import { DetailSeedType } from '@/types/target/type';
 import { getDateFromDiff } from '@/utils/date';
 import ObserverExitEvent from '../../detail/animatedBox/OpacityBox';
+import CheerUpBottomSheet from '../../detail/comment/CheerUpBottomSheet';
+import { CheerUpButton } from '../../detail/comment/CheerUpButton';
 import TaskList from '../../detail/TaskList';
 import { detailSeedStateObj } from '../SeedCard';
 import { Sticker } from './Sticker';
+import { BottomSheetType } from './UserDetatilPage';
 
 type CommonSeedDetailBodyType = {
   seed: DetailSeedType;
@@ -17,7 +18,7 @@ type CommonSeedDetailBodyType = {
 
 /** 유저와 게스트 공통으로 사용하는 컴포넌트 */
 const CommonSeedDetailBody = ({ seed }: CommonSeedDetailBodyType) => {
-  const toast = useToast();
+  const { onOpenSheet, openedSheet, onCloseSheet } = useBottomSheetState<BottomSheetType>();
   const totalRoutineCount =
     getDateFromDiff(seed.endDate, seed.startDate) * seed.routineDetails.length;
 
@@ -41,22 +42,21 @@ const CommonSeedDetailBody = ({ seed }: CommonSeedDetailBodyType) => {
 
           <div className="flex w-full justify-end">
             <Sticker>
-              <Button
-                className="bg-gray-10"
-                onClick={() => {
-                  toast({
-                    type: 'default',
-                    message: '응원해준 친구을 볼 수 있는 기능 준비중입니다!',
-                  });
+              <CheerUpButton
+                onOpen={() => {
+                  onOpenSheet('checkCheerUpNameList');
                 }}
-              >
-                <SunIcon width={30} height={30} />
-              </Button>
+              />
             </Sticker>
           </div>
         </div>
         {/* //TODO : 좋아요 UI 표현 고민해보자 */}
         <TaskList tasks={seed.routineDetails} />
+
+        <CheerUpBottomSheet
+          isOpen={openedSheet === 'checkCheerUpNameList'}
+          onClose={onCloseSheet}
+        />
       </div>
     </>
   );

--- a/src/components/feature/seed/seedDetail/UserDetatilPage.tsx
+++ b/src/components/feature/seed/seedDetail/UserDetatilPage.tsx
@@ -16,7 +16,7 @@ import ConfirmBottomSheet from '../../detail/ConfirmBottomSheet';
 import RainBackGround from '../../detail/RainBackGround';
 import CommonSeedDetailBody from './CommonSeedDetailBody';
 
-type BottomSheetType = 'askDelete';
+export type BottomSheetType = 'askDelete' | 'checkCheerUpNameList';
 
 const UserDetatilPage = () => {
   const { id } = useParams();


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->

## ✨ 작업 내용
- 응원 바텀 시트 구현 

## 📚 작업 결과
![스크린샷 2024-05-19 오전 1 39 32](https://github.com/aligo-ligo/seed-moa/assets/93697790/934c3b89-33fa-4610-be30-812af022d653)


## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

## ✅ PR 등록 전 확인 후 체크해 주세요! (x 표시 해 주세요.)

- [x] Assignees를 지정했습니다. (해당 PR 작업한 사람을 태그해 주세요)
